### PR TITLE
[MSITE-812] Missing '/' in log when deploying documentation by site:stage

### DIFF
--- a/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
@@ -447,7 +447,7 @@ public abstract class AbstractDeployMojo
                 {
                     // TODO: this also uploads the non-default locales,
                     // is there a way to exclude directories in wagon?
-                    getLog().info( "   >>> to " + repository.getUrl() + relativeDir );
+                    getLog().info( "   >>> to " + repository.getUrl() + "/" + relativeDir );
 
                     wagon.putDirectory( inputDirectory, relativeDir );
                 }


### PR DESCRIPTION
Detail: https://issues.apache.org/jira/browse/MSITE-812