### PR TITLE
[MSITE-828] Upgrade jetty to recent version. Update to java 1.8 (required for jetty)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,19 @@ under the License.
   </properties>
 
   <dependencies>
+    <!-- exclude obsolete runtime artifact included by transitive dependencies (pulled by doxia-site-renderer) -->
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-api</artifactId>
@@ -351,23 +364,19 @@ under the License.
       <scope>runtime</scope>
     </dependency>
 
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
-    </dependency>
-
     <!-- Doxia Sitetools -->
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-decoration-model</artifactId>
       <version>${doxiaSitetoolsVersion}</version>
     </dependency>
+
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-site-renderer</artifactId>
       <version>${doxiaSitetoolsVersion}</version>
     </dependency>
+
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-integration-tools</artifactId>
@@ -397,6 +406,12 @@ under the License.
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
+      <version>${jettyVersion}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
       <version>${jettyVersion}</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@ under the License.
     <pmdPluginVersion>3.0.1</pmdPluginVersion>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <jettyVersion>9.4.11.v20180605</jettyVersion>
   </properties>
 
   <dependencies>
@@ -396,32 +397,32 @@ under the License.
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.11.v20180605</version>
+      <version>${jettyVersion}</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
-      <version>9.4.11.v20180605</version>
+      <version>${jettyVersion}</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>9.4.11.v20180605</version>
+      <version>${jettyVersion}</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
-      <version>9.4.11.v20180605</version>
+      <version>${jettyVersion}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
-      <version>9.4.11.v20180605</version>
+      <version>${jettyVersion}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,8 @@ under the License.
     <projectInfoReportsPluginVersion>2.7</projectInfoReportsPluginVersion>
     <checkstylePluginVersion>2.9.1</checkstylePluginVersion>
     <pmdPluginVersion>3.0.1</pmdPluginVersion>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <dependencies>
@@ -392,20 +394,34 @@ under the License.
     </dependency>
 
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty</artifactId>
-      <version>6.1.25</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-      <version>6.1.25</version>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>9.4.11.v20180605</version>
     </dependency>
 
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+      <version>9.4.11.v20180605</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>9.4.11.v20180605</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
-      <version>6.1.25</version>
+      <version>9.4.11.v20180605</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-proxy</artifactId>
+      <version>9.4.11.v20180605</version>
       <scope>test</scope>
     </dependency>
 
@@ -533,10 +549,6 @@ under the License.
               <rules>
                 <enforceBytecodeVersion>
                   <maxJdkVersion>${maven.compiler.target}</maxJdkVersion>
-                  <excludes><!-- DOXIA-554 Markdown parser requires Java 7 (use version 1.7 if you absolutely require Java 6) -->
-                    <exclude>org.apache.maven.doxia:doxia-module-markdown</exclude>
-                    <exclude>org.nibor.autolink:autolink</exclude>
-                  </excludes>
                 </enforceBytecodeVersion>
               </rules>
               <fail>true</fail>

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@ under the License.
     <pmdPluginVersion>3.0.1</pmdPluginVersion>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <jettyVersion>9.4.11.v20180605</jettyVersion>
+    <jettyVersion>9.4.12.v20180830</jettyVersion>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
@@ -323,7 +323,11 @@ public abstract class AbstractDeployMojo
             {
                 try
                 {
-                    SettingsDecrypter settingsDecrypter = container.lookup( SettingsDecrypter.class );
+                    // The cast does not make sense, however I get when compiled with maven 3.5.4:
+                    // error: incompatible types: Object cannot be converted to SettingsDecrypter
+                    // The cast is not necessary with maven 3.3.9
+                    SettingsDecrypter settingsDecrypter =
+                            (SettingsDecrypter) container.lookup( SettingsDecrypter.class );
 
                     proxyInfo = getProxy( repository, settingsDecrypter );
                 }

--- a/src/main/java/org/apache/maven/plugins/site/run/SiteRunMojo.java
+++ b/src/main/java/org/apache/maven/plugins/site/run/SiteRunMojo.java
@@ -38,8 +38,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.site.render.AbstractSiteRenderingMojo;
 import org.apache.maven.reporting.exec.MavenReportExecution;
 import org.codehaus.plexus.util.IOUtil;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -76,7 +74,7 @@ public class SiteRunMojo
     {
         checkInputEncoding();
 
-        Server server = new Server(port);
+        Server server = new Server( port );
         server.setStopAtShutdown( true );
 
         WebAppContext webapp = createWebApplication();

--- a/src/main/java/org/apache/maven/plugins/site/run/SiteRunMojo.java
+++ b/src/main/java/org/apache/maven/plugins/site/run/SiteRunMojo.java
@@ -38,12 +38,10 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.site.render.AbstractSiteRenderingMojo;
 import org.apache.maven.reporting.exec.MavenReportExecution;
 import org.codehaus.plexus.util.IOUtil;
-import org.mortbay.jetty.Connector;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.DefaultHandler;
-import org.mortbay.jetty.nio.SelectChannelConnector;
-import org.mortbay.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.webapp.WebAppContext;
 
 /**
  * Starts the site up, rendering documents as requested for faster editing.
@@ -78,22 +76,13 @@ public class SiteRunMojo
     {
         checkInputEncoding();
 
-        Server server = new Server();
+        Server server = new Server(port);
         server.setStopAtShutdown( true );
-
-        Connector defaultConnector = getDefaultConnector();
-        server.setConnectors( new Connector[] { defaultConnector } );
 
         WebAppContext webapp = createWebApplication();
         webapp.setServer( server );
 
-        DefaultHandler defaultHandler = new DefaultHandler();
-        defaultHandler.setServer( server );
-
-        Handler[] handlers = new Handler[2];
-        handlers[0] = webapp;
-        handlers[1] = defaultHandler;
-        server.setHandlers( handlers );
+        server.setHandler( webapp );
 
         getLog().info( "Starting Jetty on http://localhost:" + port + "/" );
         try
@@ -222,14 +211,6 @@ public class SiteRunMojo
             throw new MojoExecutionException( "Unable to set up webapp", e );
         }
         return webapp;
-    }
-
-    private Connector getDefaultConnector()
-    {
-        Connector connector = new SelectChannelConnector();
-        connector.setPort( port );
-        connector.setMaxIdleTime( MAX_IDLE_TIME );
-        return connector;
     }
 
     public void setTempWebappDirectory( File tempWebappDirectory )

--- a/src/test/java/org/apache/maven/plugins/site/deploy/AbstractSiteDeployWebDavTest.java
+++ b/src/test/java/org/apache/maven/plugins/site/deploy/AbstractSiteDeployWebDavTest.java
@@ -34,7 +34,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
-import org.apache.maven.plugins.site.deploy.SimpleDavServerHandler.HttpRequest;
+
 import org.apache.maven.plugins.site.stubs.SiteMavenProjectStub;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Settings;

--- a/src/test/java/org/apache/maven/plugins/site/deploy/AuthAsyncProxyServlet.java
+++ b/src/test/java/org/apache/maven/plugins/site/deploy/AuthAsyncProxyServlet.java
@@ -21,10 +21,7 @@ package org.apache.maven.plugins.site.deploy;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -34,11 +31,14 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.maven.plugins.site.deploy.SimpleDavServerHandler.HttpRequest;
-import org.mortbay.jetty.security.B64Code;
-import org.mortbay.proxy.AsyncProxyServlet;
+import org.apache.commons.lang3.SystemUtils;
+import org.eclipse.jetty.util.B64Code;
+import org.eclipse.jetty.proxy.AsyncProxyServlet;
+import org.eclipse.jetty.proxy.AsyncProxyServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.maven.plugins.site.deploy.HttpRequest;
+
 
 /**
  * @author Olivier Lamy
@@ -108,7 +108,7 @@ public class AuthAsyncProxyServlet
             if ( proxyAuthorization != null && proxyAuthorization.startsWith( "Basic " ) )
             {
                 String proxyAuth = proxyAuthorization.substring( 6 );
-                String authorization = B64Code.decode( proxyAuth );
+                String authorization = new String(B64Code.decode( proxyAuth ));
                 String[] authTokens = authorization.split( ":" );
                 String user = authTokens[0];
                 String password = authTokens[1];

--- a/src/test/java/org/apache/maven/plugins/site/deploy/HttpRequest.java
+++ b/src/test/java/org/apache/maven/plugins/site/deploy/HttpRequest.java
@@ -1,0 +1,52 @@
+package org.apache.maven.plugins.site.deploy;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.commons.lang3.SystemUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class HttpRequest
+{
+    Map<String, String> headers = new HashMap<String,String>();
+
+    String method;
+
+    String path;
+
+    HttpRequest()
+    {
+        // nop
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder( method ).append( " path " ).append( path )
+                .append( SystemUtils.LINE_SEPARATOR );
+        for ( Map.Entry<String, String> entry : headers.entrySet() )
+        {
+            sb.append( entry.getKey() ).append( " : " ).append( entry.getValue() )
+                    .append( SystemUtils.LINE_SEPARATOR );
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/site/deploy/SimpleDavServerHandler.java
+++ b/src/test/java/org/apache/maven/plugins/site/deploy/SimpleDavServerHandler.java
@@ -36,12 +36,14 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.AbstractHandler;
-import org.mortbay.jetty.servlet.Context;
-import org.mortbay.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler.Context;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.apache.maven.plugins.site.deploy.HttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +69,7 @@ public class SimpleDavServerHandler
         this.siteTargetPath = targetPath;
         Handler repoHandler = new AbstractHandler()
         {
-            public void handle( String target, HttpServletRequest request, HttpServletResponse response, int dispatch )
+            public void handle( String target, Request r, HttpServletRequest request, HttpServletResponse response )
                 throws IOException, ServletException
             {
                 String targetPath = request.getPathInfo();
@@ -112,16 +114,17 @@ public class SimpleDavServerHandler
     {
         siteTargetPath = null;
         server = new Server( 0 );
-        Context context = new Context( server, "/", 0 );
-
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        context.setContextPath("/");
+        server.setHandler(context);
         context.addServlet( new ServletHolder( servlet ), "/" );
-        
+
         server.start();
-    }   
+    }
     
     public int getPort()
     {
-        return server.getConnectors()[0].getLocalPort();
+        return server.getURI().getPort();
     }
 
     public void stop()
@@ -131,30 +134,5 @@ public class SimpleDavServerHandler
     }
     
     
-    static class HttpRequest
-    {
-        Map<String, String> headers = new HashMap<String,String>();
-        
-        String method;
-        
-        String path;
-        
-        HttpRequest()
-        {
-            // nop
-        }
 
-        @Override
-        public String toString()
-        {
-            StringBuilder sb = new StringBuilder( method ).append( " path " ).append( path )
-                .append( SystemUtils.LINE_SEPARATOR );
-            for ( Entry<String, String> entry : headers.entrySet() )
-            {
-                sb.append( entry.getKey() ).append( " : " ).append( entry.getValue() )
-                    .append( SystemUtils.LINE_SEPARATOR );
-            }
-            return sb.toString();
-        }
-    }
 }


### PR DESCRIPTION
Hi,  I am hunting down insecure maven dependencies.

This pull requests tries to start discussion about upgrading jetty to a more recent version.

jetty 6.1.25 does include  insecure plugin repositories via its jetty-parent . Found out while I compiled a 3rd party project.

Patch is porting the  jetty code to current jetty fixing that issue.

While doing this I found that there is a inner class of a test used in normal business logic "HttpRequest". I refactored it to business logic. 

Since jetty is Java 1.8, I changed maven enforcer to check for java 1.8 project wise. Since Java 1.6 is falling out of extended support in a month, java 1.7 now unsupported and java 1.8 now being the old LTS I think there is little reason to stick with java 1.6.


