### PR TITLE
MSITE-847: Corrected link to prerequisite maven version.

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -32,7 +32,7 @@ ${project.name}
  The Site Plugin is used to generate a site for the project. The generated site also includes the project's reports
  that were configured in the POM.
 
- This is the site for <<version 3>> of the maven-site-plugin. It requires at least Maven ${prerequisiteMavenVersion} to run. If you
+ This is the site for <<version 3>> of the maven-site-plugin. It requires at least Maven ${project.prerequisites.maven} to run. If you
  are looking for <<version 2>> you can find it {{{/plugins/maven-site-plugin-2.x/index.html}here}}.
 
  Please read the {{{./migrate.html}migration guide}} if you want to upgrade from a previous version.


### PR DESCRIPTION
I'd like to add an automatic detection integration test for any links (<a> tags) without an href.  Would that be something you would support?  It would prevent errors like this occuring in the future, as well as ensure that any blue "hyperlink" text would actually take you somewhere!