### PR TITLE
[MSITE-861] remove obsolete dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,17 +215,7 @@ under the License.
 
   <dependencies>
     <!-- exclude obsolete runtime artifact included by transitive dependencies (pulled by doxia-site-renderer) -->
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>1.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+
 
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -214,9 +214,6 @@ under the License.
   </properties>
 
   <dependencies>
-    <!-- exclude obsolete runtime artifact included by transitive dependencies (pulled by doxia-site-renderer) -->
-
-
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-api</artifactId>


### PR DESCRIPTION
@michael-o 

exclusion no longer necessary with latest doxias

[INFO] +- org.apache.maven.doxia:doxia-site-renderer:jar:1.9.2:compile
[INFO] |  +- org.apache.maven.doxia:doxia-skin-model:jar:1.9.2:compile
[INFO] |  +- org.codehaus.plexus:plexus-velocity:jar:1.2:compile
[INFO] |  +- org.apache.velocity:velocity:jar:1.7:compile
[INFO] |  |  \- commons-lang:commons-lang:jar:2.4:compile
[INFO] |  +- org.apache.velocity:velocity-tools:jar:2.0:compile
[INFO] |  |  +- commons-beanutils:commons-beanutils:jar:1.7.0:compile
[INFO] |  |  +- commons-digester:commons-digester:jar:1.8:compile
[INFO] |  |  +- commons-chain:commons-chain:jar:1.1:compile
[INFO] |  |  +- dom4j:dom4j:jar:1.1:compile
[INFO] |  |  \- oro:oro:jar:2.0.8:compile
[INFO] |  \- commons-collections:commons-collections:jar:3.2.2:compile
