### PR TITLE
Fix script injection example in docs

### DIFF
--- a/src/site/apt/examples/sitedescriptor.apt
+++ b/src/site/apt/examples/sitedescriptor.apt
@@ -237,7 +237,7 @@ Configuring the Site Descriptor
   <body>
     ...
     <head>
-      <![CDATA[<script src="http://www.google-analytics.com/urchin.js" type="text/javascript" />]]>
+      <![CDATA[<script src="http://www.google-analytics.com/urchin.js" type="text/javascript"></script>]]>
     </head>
     ...
   </body>


### PR DESCRIPTION
Example is not good since self-closing tag wont work, so it is changed to correct example. 
See [stackoverflow](https://stackoverflow.com/questions/4531772/can-the-script-tag-not-be-self-closed/4531793) for more info.