### PR TITLE
[MSITE-871] Upgrade Maven Javadoc Plugin in integration tests

### DIFF
--- a/src/it/projects/MSITE-484/pom.xml
+++ b/src/it/projects/MSITE-484/pom.xml
@@ -66,7 +66,7 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.2.0</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/src/it/projects/MSITE-497/pom.xml
+++ b/src/it/projects/MSITE-497/pom.xml
@@ -43,7 +43,7 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.7</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -65,7 +65,6 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0-M1</version>
       </plugin>
     </plugins>
   </reporting>

--- a/src/it/projects/MSITE-506/pom.xml
+++ b/src/it/projects/MSITE-506/pom.xml
@@ -57,7 +57,7 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.2.0</version>
         <configuration>
           <includeDependencySources>true</includeDependencySources>
           <detectOfflineLinks>false</detectOfflineLinks>

--- a/src/it/projects/MSITE-512/parent-usage-test/pom.xml
+++ b/src/it/projects/MSITE-512/parent-usage-test/pom.xml
@@ -57,7 +57,7 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.2.0</version>
         <reportSets>
           <reportSet>
             <id>single</id>

--- a/src/it/projects/MSITE-665/pom.xml
+++ b/src/it/projects/MSITE-665/pom.xml
@@ -82,7 +82,7 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.2.0</version>
         <reportSets>
           <reportSet>
             <reports>


### PR DESCRIPTION
These test failed on macOS with Java above 8; now they pass with
Java 8, 11 and 15 on macOS.