### PR TITLE
Upgrade to maven 3.2.5 + Java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.0.5</mavenVersion>
+    <mavenVersion>3.2.5</mavenVersion>
     <javaVersion>8</javaVersion>
 
     <!-- for dependencies -->
@@ -249,6 +249,12 @@ under the License.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-aether-provider</artifactId>
       <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>
@@ -401,6 +407,12 @@ under the License.
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-integration-tools</artifactId>
       <version>${doxiaSitetoolsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-container-default</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Wagon -->
@@ -501,7 +513,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>2.1</version>
+      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/maven/plugins/site/deploy/SiteDeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/site/deploy/SiteDeployMojoTest.java
@@ -21,7 +21,7 @@ package org.apache.maven.plugins.site.deploy;
 
 import org.apache.maven.artifact.manager.WagonManager;
 //import org.apache.maven.wagon.repository.Repository;
-import org.codehaus.plexus.PlexusTestCase;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +32,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith( JUnit4.class )
 public class SiteDeployMojoTest
-    extends PlexusTestCase
+    extends AbstractMojoTestCase
 {
     private WagonManager wagonManager;
 
@@ -102,7 +102,7 @@ public class SiteDeployMojoTest
     public void testGetProxyInfoForRepositoryHostWildcardNoMatchNonProxyHosts2()
     {
         wagonManager.
-        
+
         wagonManager.addProxy( "scp", "localhost", 8080, "my-user", "my-password", "*mycompany" );
         ProxyInfo proxyInfo = SiteDeployMojo.getProxyInfo( repository, wagonManager );
         assertNotNull( "ProxyInfo must be found because 'repository-host' not in nonProxyHosts list", proxyInfo );


### PR DESCRIPTION
Upgrade plugin to Maven 3.2.5

This will have ITs failed, as there is some bug re XML encoded it ISO5592-1. If you search/replace all ISO8859-1 (and convert files) -- there is site-sd-lang that uses french ISO -- so all to UTF-8 and files converted as well, then all IT pass OK.