### PR TITLE
plugin webpage: remove obsolete link to template file

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -103,8 +103,6 @@ ${project.name}
 
 ** Site Template
 
-     * {{{./examples/templatefile.html}Changing the Template File}}
-
      * {{{./examples/creatingskins.html}Creating Skins}}
 
 ** Deploying


### PR DESCRIPTION
A link exist on the page to filetemplate : https://maven.apache.org/plugins/maven-site-plugin/index.html

but it was removed in https://github.com/apache/maven-site-plugin/commit/5f81392dadcc6899c17e1c64f6957229514118ff

Kind of typo fixes lazy to do jira for that :D

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)


