### PR TITLE
Fix typos in history.apt and faq.fml

### DIFF
--- a/src/site/apt/history.apt
+++ b/src/site/apt/history.apt
@@ -34,7 +34,7 @@ Maven Site Plugin History
  Maven Site Plugin uses:
 
   * {{{/doxia/}Doxia}} to parse {{{/doxia/references/}many markup languages}} then render HTML: see
-  {{{./examples/creating-content.html}Creating Content}} documentation for mode details (particularly which markups
+  {{{./examples/creating-content.html}Creating Content}} documentation for more details (particularly which markups
   are enabled by default in maven-site-plugin and how to add one),
 
   * {{{/doxia/doxia-sitetools/doxia-site-renderer/}Doxia Sitetools - Site Renderer}} to integrate document content into
@@ -52,15 +52,15 @@ Maven Site Plugin History
 
   Given this layered approach, rendering issues reported to {{{https://issues.apache.org/jira/projects/MSITE}MSITE Maven Site Plugin issue tracker}}
   are often translated to {{{https://issues.apache.org/jira/projects/DOXIA}Doxia}} or
-  {{{https://issues.apache.org/jira/projects/DOXIASITETOOLS}Doxia Sitetools}}, and issues fixed in
-  Doxia or Doxia Sitetools benefit to maven-site-plugin once dependency is upgraded.
+  {{{https://issues.apache.org/jira/projects/DOXIASITETOOLS}Doxia Sitetools}} issues. Any issues fixed in
+  Doxia or Doxia Sitetools are inherited to the maven-site-plugin once its dependency is updated.
 
   Knowing which version of
   maven-site-plugin uses which version of Doxia or Doxia Sitetools is useful to choose to which version to upgrade
   maven-site-plugin to benefit from a fix: this is the basis for the  {{{./migrate.html}simplified migration guide}}.
 
 *-----------------*--------------------*--------*------------------*--------------------*---*-------*---------------*
-|| relelease date || maven-site-plugin || {{{/doxia/}Doxia}} || {{{/doxia/doxia-sitetools/}Doxia Sitetools}} || {{{/shared/maven-reporting-exec/}Maven Reporting Executor}} || minimum Java || minimum  Maven || Comment
+|| release date || maven-site-plugin || {{{/doxia/}Doxia}} || {{{/doxia/doxia-sitetools/}Doxia Sitetools}} || {{{/shared/maven-reporting-exec/}Maven Reporting Executor}} || minimum Java || minimum  Maven || Comment
 *-----------------*--------------------*--------*------------------*--------------------*---*-------*---------------*
 | 2024-07         | 4.0.0-M16          |        |                  |
 *-----------------*--------------------*--------*------------------*--------------------*---*-------*---------------*

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -29,7 +29,7 @@ under the License.
           <dt><code>mvn site</code></dt>
           <dd>
             Calls the <i>site</i> <b>phase</b> of the site <b>lifecycle</b>.
-            Full site lifecycle consists in the following life cycle phases: <code>pre-site</code>, <code>site</code>, <code>post-site</code> and <code>site-deploy</code>.
+            Full site lifecycle consists of the following life cycle phases: <code>pre-site</code>, <code>site</code>, <code>post-site</code> and <code>site-deploy</code>.
             See <a href="/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference">Lifecycle Reference</a>.
             Then it calls plugin goals associated to <code>pre-site</code> and <code>site</code> phases.</dd>
           <dt><code>mvn site:site</code></dt>
@@ -38,8 +38,8 @@ under the License.
         </dl>
       </answer>
     </faq>
-    <faq id="How do I Integrate static (X)HTML pages into my Maven site">
-      <question>How do I Integrate static (X)HTML pages into my Maven site?</question>
+    <faq id="How do I integrate static (X)HTML pages into my Maven site">
+      <question>How do I integrate static (X)HTML pages into my Maven site?</question>
       <answer>
         <p>
         You can integrate your static pages by following these steps:


### PR DESCRIPTION
Trivial changes in the documentation.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

@michael-o hopefully everything works now.


