### PR TITLE
Avoid touching old plexus anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,9 +299,9 @@ under the License.
 
     <!-- Plexus -->
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-plexus</artifactId>
-      <version>1.4.2</version>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <version>0.9.0.M3</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
@@ -23,6 +23,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.maven.doxia.site.inheritance.URIPathDescriptor;
 import org.apache.maven.doxia.tools.SiteTool;
@@ -53,8 +54,6 @@ import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.observers.Debug;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 
 /**
  * Abstract base class for deploy mojos.
@@ -124,7 +123,7 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
     private Site deploySite;
 
     @Component
-    private PlexusContainer container;
+    private Map<String, Wagon> wagons;
 
     @Component
     SettingsDecrypter settingsDecrypter;
@@ -277,16 +276,15 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
         if (protocol == null) {
             throw new MojoExecutionException("Unspecified protocol");
         }
-        try {
-            Wagon wagon = container.lookup(Wagon.class, protocol.toLowerCase(Locale.ROOT));
-            if (!wagon.supportsDirectoryCopy()) {
-                throw new MojoExecutionException(
-                        "Wagon protocol '" + repository.getProtocol() + "' doesn't support directory copying");
-            }
-            return wagon;
-        } catch (ComponentLookupException e) {
-            throw new MojoExecutionException("Cannot find wagon which supports the requested protocol: " + protocol, e);
+        Wagon wagon = wagons.get(protocol.toLowerCase(Locale.ROOT));
+        if (wagon == null) {
+            throw new MojoExecutionException("Cannot find wagon which supports the requested protocol: " + protocol);
         }
+        if (!wagon.supportsDirectoryCopy()) {
+            throw new MojoExecutionException(
+                    "Wagon protocol '" + repository.getProtocol() + "' doesn't support directory copying");
+        }
+        return wagon;
     }
 
     public AuthenticationInfo getAuthenticationInfo(String id) {
@@ -558,7 +556,7 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
                     uri.append(c);
                 } else {
                     uri.append('%');
-                    uri.append(Integer.toHexString((int) c));
+                    uri.append(Integer.toHexString(c));
                 }
             }
             return uri.toString();


### PR DESCRIPTION
Why direct lookup, when it goes without touching
the plexus APIs.