### PR TITLE
[MSITE-1035] use jquery as example js in site descriptor

### DIFF
--- a/src/site/apt/examples/sitedescriptor.apt
+++ b/src/site/apt/examples/sitedescriptor.apt
@@ -237,7 +237,7 @@ Configuring the Site Descriptor
   <body>
     ...
     <head>
-      <![CDATA[<script src="http://www.google-analytics.com/urchin.js" type="text/javascript"></script>]]>
+      <![CDATA[<script src="/js/jquery.js" type="text/javascript"></script>]]>
     </head>
     ...
   </body>


### PR DESCRIPTION
see https://github.com/apache/maven-site/issues/660#issuecomment-2669720009
