### PR TITLE
Configure Wagon from settings.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,14 @@ under the License.
       <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- reusing component to configure Wagon -->
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-wagon</artifactId>
+      <version>1.4.1</version>
+      <!-- version shipping with Maven 3.6.3-->
+      <scope>compile</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
@@ -55,6 +55,9 @@ import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.observers.Debug;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.transport.wagon.WagonConfigurator;
 
 /**
  * Abstract base class for deploy mojos.
@@ -129,6 +132,8 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
     @Inject
     SettingsDecrypter settingsDecrypter;
 
+    @Inject
+    private WagonConfigurator wagonConfigurator;
     /**
      * {@inheritDoc}
      */
@@ -284,6 +289,28 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
         if (!wagon.supportsDirectoryCopy()) {
             throw new MojoExecutionException(
                     "Wagon protocol '" + repository.getProtocol() + "' doesn't support directory copying");
+        }
+        // retrieve relevant settings
+        Server server = settings.getServer(repository.getId());
+        // taken over from
+        // https://github.com/apache/maven/blob/18a52647884dcc822eb04bf5a3265a21dc83256c/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java#L242
+        if (server != null && server.getConfiguration() != null) {
+            Xpp3Dom dom = (Xpp3Dom) server.getConfiguration();
+            for (int i = dom.getChildCount() - 1; i >= 0; i--) {
+                Xpp3Dom child = dom.getChild(i);
+                if ("wagonProvider".equals(child.getName())) {
+                    dom.removeChild(i);
+                }
+            }
+            XmlPlexusConfiguration config = new XmlPlexusConfiguration(dom);
+            try {
+                // use Wagon configurator from Resolver
+                wagonConfigurator.configure(wagon, config);
+            } catch (Exception e) {
+                throw new MojoExecutionException(
+                        "Error configuring wagon with server configuration for server id '" + repository.getId() + "'",
+                        e);
+            }
         }
         return wagon;
     }


### PR DESCRIPTION
This regressed with
https://github.com/apache/maven-site-plugin/commit/e414d23496e5bd3949774f2f8267e93eebf69f10

This closes #1217

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSITE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MSITE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSITE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

