### PR TITLE
enable build with Maven 4

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
+    with:
+      maven4-enabled: true

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
+    with:
+      maven4-enabled: true


### PR DESCRIPTION
build with Maven 4 in CI, to check that maven-site-plugin works with Maven 4

and complete the table on https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=406620656#Maven4.0.0GAchecklist-Maven4API