### PR TITLE
fix image insertion

### DIFF
--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -35,6 +35,7 @@ The Site Plugin uses:
 - [Doxia](/doxia/) to parse [many markup languages](/doxia/references/) then render HTML: see [Creating Content](./examples/creating-content.html) documentation for more details \(particularly which markups are enabled by default in maven-site-plugin and how to add one\),
 - [Doxia Sitetools - Site Renderer](/doxia/doxia-sitetools/doxia-site-renderer/) to integrate document content into a template packaged as a skin: see [Creating Skins](./examples/creatingskins.html) documentation for more details,
 - [Maven Reporting Executor](/shared/maven-reporting-exec/) to manage reports execution \(since Maven 3\).
+
 ![Developer Overview](developer-overview.png)
 
 #[[##]]# Goals Overview


### PR DESCRIPTION
see https://maven.apache.org/plugins-archives/maven-site-plugin-3.22.0/

image is in the "Reporting Executor" bullet point
should be after all bullet points, on its own paragraph