### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/src/site/markdown/examples/configuring-reports.md
+++ b/src/site/markdown/examples/configuring-reports.md
@@ -61,7 +61,7 @@ If you have included the appropriate `<menu ref="reports"/>` tag in your [site d
 
 **Note:** Many report plugins provide a parameter called `outputDirectory` or similar to specify the destination for their report outputs. This parameter is only relevant if the report plugin is run standalone, i.e. by invocation directly from the command line. In contrast, when reports are generated as part of the site, the configuration of the Maven Site Plugin will determine the effective output directory to ensure that all reports end up in a common location.
 
-Check out reporting plugins \(&quot;R&quot; value in the &quot;Type&quot; column\) in the [plugins page](/plugins/), for a list of available reporting plugins from Apache Maven Team.
+Check out reporting plugins (&quot;R&quot; value in the &quot;Type&quot; column) in the [plugins page](/plugins/), for a list of available reporting plugins from Apache Maven Team.
 
 # Selecting Reports from a Plugin: Configuring Report Sets
 

--- a/src/site/markdown/examples/creating-content.md.vm
+++ b/src/site/markdown/examples/creating-content.md.vm
@@ -56,12 +56,12 @@ Here&apos;s an example of a directory structure for a site:
 
 The `${basedir}/src/site` directory which contains a site descriptor along with various directories corresponding to the supported document formats. Let&apos;s take a look at examples of the various document formats.
 
-- APT: The APT format \(&quot;Almost Plain Text&quot;\) is a wiki-like format that allows you to write simple, structured documents \(like this one\) very quickly. A full reference of the [ APT Format](/doxia/references/apt-format.html) is available.
+- APT: The APT format (&quot;Almost Plain Text&quot;) is a wiki-like format that allows you to write simple, structured documents (like this one) very quickly. A full reference of the [ APT Format](/doxia/references/apt-format.html) is available.
 - FML: The FML format is the FAQ format. This is the same that were used in Maven 1\.x. For more info about the [FML Format](/doxia/references/fml-format.html) check the [Doxia](/doxia/) site.
 - XDoc: The XDoc format is the same as [ used in Maven 1\.x](/maven-1.x/using/site.html). A reference for the [ XDoc Format](/doxia/references/xdoc-format.html) is available.
-- Markdown \(since maven-site-plugin 3\.3\): [ Markdown](http://en.wikipedia.org/wiki/Markdown) is a widespread Markup language.
+- Markdown (since maven-site-plugin 3\.3): [ Markdown](http://en.wikipedia.org/wiki/Markdown) is a widespread Markup language.
 
-Other formats are available, but the above four are recognized by default by the site plugin. Any other document format for which a Doxia parser exists can be used as well \(see the list of [Doxia Markup Languages](/doxia/references/index.html)\), but in this case you need to add the corresponding Doxia dependency to your site plugin configuration, as explained in the last paragraph. Note that Doxia also supports several output formats, the site plugin only creates XHTML5\.
+Other formats are available, but the above four are recognized by default by the site plugin. Any other document format for which a Doxia parser exists can be used as well (see the list of [Doxia Markup Languages](/doxia/references/index.html)), but in this case you need to add the corresponding Doxia dependency to your site plugin configuration, as explained in the last paragraph. Note that Doxia also supports several output formats, the site plugin only creates XHTML5\.
 
 Note that all of the above is optional - just one index file is required in one of the input trees. The paths under each format will be merged together to form the root directory of the site. After running &apos;`mvn site:site`&apos; on the example above you will end up with this in your `target` directory:
 
@@ -155,7 +155,7 @@ To enable multiple locales, or languages, add a configuration similar to the fol
 </project>
 ```
 
-This will generate both a default \(`Locale#ROOT`\) and a French version of the site. It will be generated at the root of the site, with a copy of the French translation of the site in the `fr/` subdirectory.
+This will generate both a default (`Locale#ROOT`) and a French version of the site. It will be generated at the root of the site, with a copy of the French translation of the site in the `fr/` subdirectory.
 
 To add your own content for that translation instead of using the default, create a subdirectory with that locale&apos;s name in your site directory and create a new site descriptor with the name of the locale in the file name. For example:
 
@@ -173,5 +173,5 @@ To add your own content for that translation instead of using the default, creat
       +- site_fr.xml      (French site descriptor)
 ```
 
-With one site descriptor per language, the translated site\(s\) can evolve independently.
+With one site descriptor per language, the translated site(s) can evolve independently.
 

--- a/src/site/markdown/examples/creatingskins.md
+++ b/src/site/markdown/examples/creatingskins.md
@@ -33,7 +33,7 @@ For an in-depth discussion of site customization, please have a look at [ Maven:
 
 A skin contains the following elements:
 
-- Resources to copy into each project \(such as images used by the CSS\)
+- Resources to copy into each project (such as images used by the CSS)
 - A couple of CSS files, containing the visual styling
 - A Velocity template in `/META-INF/maven/site.vm` for an alternate HTML rendering of the site.
 - Since Maven Site Plugin 3\.5, an optional [skin descriptor](/doxia/doxia-sitetools/doxia-skin-model/index.html) in `/META-INF/maven/skin.xml` containing meta-data about the skin

--- a/src/site/markdown/examples/inheritance-site-distribution-management.md
+++ b/src/site/markdown/examples/inheritance-site-distribution-management.md
@@ -59,5 +59,5 @@ bar/ (root of site)
 └── report.html
 ```
 
-As you can see the site content of the parent POM is located in the root of the site directory, while the content of each project using the parent POM \(called &quot;project-A&quot; and &quot;project-B&quot; in the example\) is located inside a subdirectory.
+As you can see the site content of the parent POM is located in the root of the site directory, while the content of each project using the parent POM (called &quot;project-A&quot; and &quot;project-B&quot; in the example) is located inside a subdirectory.
 

--- a/src/site/markdown/examples/multimodule.md
+++ b/src/site/markdown/examples/multimodule.md
@@ -35,15 +35,15 @@ To preview the whole tree of a multi-module site, you can use the [`site:stage`]
 
 [`site:deploy`](../deploy-mojo.html) does the same thing as `site:stage`, but uses the url defined in the `<distributionManagement>` element of the pom as deployment location. This is usually a remote url, but both remote protocols like `scp` and local protocols like `file` are supported.
 
-Finally, [`site:stage-deploy`](../stage-deploy-mojo.html) does the same thing as `site:deploy` but uses the `stagingDirectory` parameter as deployment location. This can be used to deploy the site to a remote staging area \(`site:stage` is always local\).
+Finally, [`site:stage-deploy`](../stage-deploy-mojo.html) does the same thing as `site:deploy` but uses the `stagingDirectory` parameter as deployment location. This can be used to deploy the site to a remote staging area (`site:stage` is always local).
 
 **Notes:**
 
-- If subprojects inherit the \(distribution\) site URL from a parent POM, they will automatically append their _artifactId_ to form their effective deployment location. This goes for both the project url and the url defined in the `<distributionManagement>` element of the pom.
+- If subprojects inherit the (distribution) site URL from a parent POM, they will automatically append their _artifactId_ to form their effective deployment location. This goes for both the project url and the url defined in the `<distributionManagement>` element of the pom.
 - If your multi-module tree does not follow the Maven conventions, or if module directories are named differently than module artifacts, you have to specify the url&apos;s for **each** child project. See also [`How does the Site Plugin use the <url> element in the POM?`](../faq.html#Use_of_url).
-- The pom.xml of the topmost project in a multi-module build must define the distributionManagement URL element \(called &quot;rootURL&quot; hereafter\). The rootURL must be the topmost distributionManagement URL in the multi-module project, implying that any distributionManagement URL defined within another project in a multimodule build must start with the rootURL and append unique paths \(to be situated &quot;below&quot; the rootURL\).
+- The pom.xml of the topmost project in a multi-module build must define the distributionManagement URL element (called &quot;rootURL&quot; hereafter). The rootURL must be the topmost distributionManagement URL in the multi-module project, implying that any distributionManagement URL defined within another project in a multimodule build must start with the rootURL and append unique paths (to be situated &quot;below&quot; the rootURL).
 - All projects in multi-module builds must define unique distributionManagement url elements, below/under the root distributionManagement URL in terms of URL path.
-- If the artifactId and module name \(i.e. directory name\) are not identical for any project within a multi-module build, the distributionManagement URL element must be defined in the pom.xml file in the project.
+- If the artifactId and module name (i.e. directory name) are not identical for any project within a multi-module build, the distributionManagement URL element must be defined in the pom.xml file in the project.
 ## Inheritance
 
 Site descriptors are inherited along the same lines as project descriptors are. If you want your project&apos;s site descriptor to be inherited, you need to attach it to the project&apos;s main artifact. You use the [`site:attach-descriptor`](../attach-descriptor-mojo.html) goal to attach the site descriptor to your project&apos;s main artifact.

--- a/src/site/markdown/examples/site-deploy-to-sourceforge.net.md
+++ b/src/site/markdown/examples/site-deploy-to-sourceforge.net.md
@@ -38,7 +38,7 @@ Both of these mean that if you attempt to deploy your site without following the
     ssh -t <username>,<project name>@shell.sf.net create
     ```
 
-- Use `shell.sourceforge.net` \(instead of `web.sourceforge.net`\) in you site URL
+- Use `shell.sourceforge.net` (instead of `web.sourceforge.net`) in you site URL
 
     ```unknown
       ...
@@ -75,7 +75,7 @@ For path information and login help, type "sf-help".
 -bash-3.2$
 ```
 
-### Use `shell.sourceforge.net` \(instead of `web.sourceforge.net`\) in you site URL
+### Use `shell.sourceforge.net` (instead of `web.sourceforge.net`) in you site URL
 
 In the project&apos;s `pom.xml`:
 

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -32,9 +32,9 @@ Please read the [migration guide](./migrate.html) if you want to upgrade from a 
 
 The Site Plugin uses:
 
-- [Doxia](/doxia/) to parse [many markup languages](/doxia/references/) then render HTML: see [Creating Content](./examples/creating-content.html) documentation for more details \(particularly which markups are enabled by default in maven-site-plugin and how to add one\),
+- [Doxia](/doxia/) to parse [many markup languages](/doxia/references/) then render HTML: see [Creating Content](./examples/creating-content.html) documentation for more details (particularly which markups are enabled by default in maven-site-plugin and how to add one),
 - [Doxia Sitetools - Site Renderer](/doxia/doxia-sitetools/doxia-site-renderer/) to integrate document content into a template packaged as a skin: see [Creating Skins](./examples/creatingskins.html) documentation for more details,
-- [Maven Reporting Executor](/shared/maven-reporting-exec/) to manage reports execution \(since Maven 3\).
+- [Maven Reporting Executor](/shared/maven-reporting-exec/) to manage reports execution (since Maven 3).
 
 ![Developer Overview](developer-overview.png)
 
@@ -47,7 +47,7 @@ The Site Plugin has the following goals:
 - [site:run](./run-mojo.html) starts a server, rendering documents on-demand (while requested) for faster previews. It uses Jetty as the web server.
 - [site:stage](./stage-mojo.html) generates a site in a local staging or mock directory based on the site URL specified in the `<distributionManagement>` section of the POM. It can be used to test that links between module sites in a multi module build work. This goal requires the site to already have been generated using the site goal, such as by calling `mvn site`.
 - [site:stage-deploy](./stage-deploy-mojo.html) deploys the generated site to a staging or mock directory to the site URL specified in the `<distributionManagement>` section of the POM.
-- [site:attach-descriptor](./attach-descriptor-mojo.html) adds the site descriptor \(`site.xml`\) to the list of files to be installed/deployed. For more references of the site descriptor, [here&apos;s a link](./examples/sitedescriptor.html).
+- [site:attach-descriptor](./attach-descriptor-mojo.html) adds the site descriptor (`site.xml`) to the list of files to be installed/deployed. For more references of the site descriptor, [here&apos;s a link](./examples/sitedescriptor.html).
 - [site:jar](./jar-mojo.html) bundles the site output into a JAR so that it can be deployed to a repository.
 - [site:effective-site](./effective-site-mojo.html) calculates the effective site descriptor, after inheritance and interpolation.
 - [site:auto-refresh](./auto-refresh-mojo.html) renders the site once and then watches for changes in the source files. If a change is detected, the Doxia source will be re-rendered.

--- a/src/site/markdown/migrate.md
+++ b/src/site/markdown/migrate.md
@@ -45,7 +45,7 @@ The Site Plugin has had a couple of upgrades that requires the user to make adju
         </plugin>
     ```
 
-- Site Decoration Model 1\.7\.0 has changed type for `head` and `footer` from `DOM` to `String`: if your `site.xml` \(or one parent\) contains XML content, you&apos;ll need to escape it, usually by adding `<![CDATA[` and `]]>` around the content:
+- Site Decoration Model 1\.7\.0 has changed type for `head` and `footer` from `DOM` to `String`: if your `site.xml` (or one parent) contains XML content, you&apos;ll need to escape it, usually by adding `<![CDATA[` and `]]>` around the content:
 
     ```unknown
     <project xmlns="http://maven.apache.org/DECORATION/1.7.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -62,7 +62,7 @@ The Site Plugin has had a couple of upgrades that requires the user to make adju
     </project>
     ```
 
-- Interpolation of `${project.*}` and `${*}` expressions in `site.xml` have changed to be consistent with equivalent feature in Maven `pom.xml`: interpolation is now done _after_ inheritance. For `site.xml`, this may lead to failures on urls \(often on `${project.url}` expression\), that are expected to be rebased during inheritance: a new _early interpolation_ feature has been added in Maven Site Plugin 3\.5\.1 throught `${this.*}` expressions \(see [ Doxia Integration Tools reference documentation](/doxia/doxia-sitetools/doxia-integration-tools/index.html)\). With this feature \(for example `${this.url}` or `${this.customProperty}` expressions\), you&apos;ll get former `site.xml` interpolation result.
+- Interpolation of `${project.*}` and `${*}` expressions in `site.xml` have changed to be consistent with equivalent feature in Maven `pom.xml`: interpolation is now done _after_ inheritance. For `site.xml`, this may lead to failures on urls (often on `${project.url}` expression), that are expected to be rebased during inheritance: a new _early interpolation_ feature has been added in Maven Site Plugin 3\.5\.1 throught `${this.*}` expressions (see [ Doxia Integration Tools reference documentation](/doxia/doxia-sitetools/doxia-integration-tools/index.html)). With this feature (for example `${this.url}` or `${this.customProperty}` expressions), you&apos;ll get former `site.xml` interpolation result.
 
 ## From 2\.x to 3\.x
 

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -26,7 +26,7 @@ date: 2012-01-12
 
 # Usage
 
-You can put additional content \(e.g. documentation, resources, etc.\) in your site. See [Creating Content](./examples/creating-content.html) for more information on this. If you want to change the menus, breadcrumbs, links or logos on your pages you need to add and configure a [site descriptor](./examples/sitedescriptor.html). If you like, you also can let Maven generate some [reports](./examples/configuring-reports.html) for you, based on the contents of your POM.
+You can put additional content (e.g. documentation, resources, etc.) in your site. See [Creating Content](./examples/creating-content.html) for more information on this. If you want to change the menus, breadcrumbs, links or logos on your pages you need to add and configure a [site descriptor](./examples/sitedescriptor.html). If you like, you also can let Maven generate some [reports](./examples/configuring-reports.html) for you, based on the contents of your POM.
 
 <!-- MACRO{toc|section=1|fromDepth=2|toDepth=3} -->
 
@@ -42,7 +42,7 @@ By default, the resulting site will be in the `target/site/` directory.
 
 **Note:** If you have a multi module project, then the links between the parent and child modules will _not_ work when you use `mvn site` or `mvn site:site`. If you want to use those links, you should use `mvn site:stage` instead. You can read more about that goal further down on this page in the section called &apos;_Staging a Site_&apos;.
 
-**Note:** For performance reasons, Maven compares the timestamps of generated files and corresponding source documents, and only regenerates documents that have changed since the last build. However, this only applies to documentation source documents \(apt, xdoc,...\). If you change anything in your `site.xml`, any relevant sections in your pom, or any relevant properties or resource files, you should generate the site from scratch to make sure all references and links are correct.
+**Note:** For performance reasons, Maven compares the timestamps of generated files and corresponding source documents, and only regenerates documents that have changed since the last build. However, this only applies to documentation source documents (apt, xdoc,...). If you change anything in your `site.xml`, any relevant sections in your pom, or any relevant properties or resource files, you should generate the site from scratch to make sure all references and links are correct.
 
 ## Deploying a Site
 
@@ -121,7 +121,7 @@ The server will, by default, be started on `http://localhost:8080/`. See [https:
 
 **Note:** Running a site only works for single-module sites. To preview a multi-module site one should use `site:stage`.
 
-## Rebuilding a Published \(Released\) Site
+## Rebuilding a Published (Released) Site
 
-In general, site documentation is published as part of a release. This means that changes to the documentation depend on a new release before being visible _or_ you must accept that the documentation refers to a snapshot version instead of the latest release version. To solve that problem, you first need to configure your project for reproducibility by setting the `project.build.outputTimestamp` model property. Then branch off from the SCM tag you want to modify, perform the changes, commit them and then rebuild, finally publish updated site. The underlying Maven Doxia Sitetools will automatically inject that property as `publishDate` Velocity context property into the site and the skin won&apos;t render a newer \(current\) date, but use this one. Checkout the `publishDate` IT for configuration details.
+In general, site documentation is published as part of a release. This means that changes to the documentation depend on a new release before being visible _or_ you must accept that the documentation refers to a snapshot version instead of the latest release version. To solve that problem, you first need to configure your project for reproducibility by setting the `project.build.outputTimestamp` model property. Then branch off from the SCM tag you want to modify, perform the changes, commit them and then rebuild, finally publish updated site. The underlying Maven Doxia Sitetools will automatically inject that property as `publishDate` Velocity context property into the site and the skin won&apos;t render a newer (current) date, but use this one. Checkout the `publishDate` IT for configuration details.
 


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.