### PR TITLE
Drop branch protection for the retired maven-site-plugin-3.12.x line

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,7 +30,6 @@ github:
     rebase: true
   protected_branches:
     master: { }
-    maven-site-plugin-3.12.x: { }
   autolink_jira:
     - MSITE
   del_branch_on_merge: true


### PR DESCRIPTION
Prerequisite for retiring `maven-site-plugin-3.12.x`; see apache/maven-doxia#1079 for the containment evidence
and what the retirement costs. Nothing else in the file changes.

*This change was created with AI assistance.*
