### PR TITLE
[MSITE-1033] Detect inheritance for SCM site URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,11 @@ under the License.
       <artifactId>maven-archiver</artifactId>
       <version>3.6.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.scm</groupId>
+      <artifactId>maven-scm-api</artifactId>
+      <version>2.1.0</version>
+    </dependency>
 
     <!-- dependencies to annotations -->
     <dependency>

--- a/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
@@ -22,10 +22,12 @@ import javax.inject.Inject;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.maven.doxia.site.inheritance.URIPathDescriptor;
 import org.apache.maven.doxia.tools.SiteTool;
@@ -37,6 +39,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.site.AbstractSiteMojo;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.scm.provider.ScmUrlUtils;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
@@ -520,6 +523,106 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
     }
 
     /**
+     * Extracts the provider-specific URL from an SCM URL for comparison purposes.
+     * For non-SCM URLs, returns the original URL.
+     * For SCM URLs with SCP-like syntax (e.g., git@github.com:user/repo.git),
+     * converts them to a comparable format.
+     * For hierarchical SCM systems like SVN, normalizes the scheme to enable
+     * proper comparison of URLs that differ only in http vs https.
+     *
+     * @param url the URL to process
+     * @return the provider-specific URL for SCM URLs, or the original URL otherwise
+     */
+    static String extractComparableUrl(String url) {
+        if (url != null && url.startsWith("scm:")) {
+            // Extract the SCM provider (e.g., "git", "svn")
+            String provider = ScmUrlUtils.getProvider(url);
+
+            // Extract the provider-specific part of the SCM URL
+            // For example: "scm:git:https://github.com/user/repo.git" -> "https://github.com/user/repo.git"
+            String providerSpecificPart = ScmUrlUtils.getProviderSpecificPart(url);
+            if (providerSpecificPart != null && !providerSpecificPart.isEmpty()) {
+                // Handle SCP-like Git syntax (e.g., git@github.com:user/repo.git or user@host:path)
+                // Convert it to a more standard format for comparison
+                // Note: This is a heuristic check - we look for the pattern of user@host:path
+                // where the colon comes after the @ symbol and is followed by a path
+                if (providerSpecificPart.contains("@")
+                        && !providerSpecificPart.startsWith("http://")
+                        && !providerSpecificPart.startsWith("https://")
+                        && !providerSpecificPart.startsWith("ssh://")) {
+                    // Find the @ symbol and look for the first : after it that's not part of a URL scheme
+                    int atIndex = providerSpecificPart.lastIndexOf('@');
+                    int colonIndex = providerSpecificPart.indexOf(':', atIndex);
+
+                    // Verify this looks like SCP syntax: user@host:path
+                    // The colon should come after @ and before the end
+                    if (atIndex >= 0 && colonIndex > atIndex + 1 && colonIndex < providerSpecificPart.length() - 1) {
+                        String host = providerSpecificPart.substring(atIndex + 1, colonIndex);
+                        String path = providerSpecificPart.substring(colonIndex + 1);
+                        // Convert to a pseudo-URL format for comparison
+                        // Note: IPv6 addresses in brackets are handled by this approach
+                        // as the brackets will be preserved in the host part
+                        return "ssh://" + host + "/" + path;
+                    }
+                }
+
+                // For hierarchical VCS systems like SVN, normalize the scheme to allow
+                // comparison of URLs that differ only in http vs https
+                // SVN repositories can be accessed via both protocols and should be considered the same
+                if ("svn".equalsIgnoreCase(provider) && providerSpecificPart.startsWith("https://")) {
+                    // Normalize https to http for SVN URLs to enable proper comparison
+                    return "http" + providerSpecificPart.substring(5);
+                }
+
+                // Return the provider-specific part as-is for standard URLs or
+                // if SCP syntax conversion is not applicable
+                return providerSpecificPart;
+            }
+        }
+        return url;
+    }
+
+    /**
+     * Returns whether a child repository lies within a parent repository, which is what makes them one site
+     * to deploy. The host must match and the child path must be the parent path or below it.
+     * <p>
+     * Host, scheme and port alone do not tell them apart: two repositories on the same forge, such as
+     * {@code github.com/org/parent.git} and {@code github.com/org/child.git}, share all three and are still
+     * unrelated sites. This is stricter than {@link URIPathDescriptor#sameSite}, so it applies only to SCM
+     * URLs, where the path names the repository.
+     *
+     * @param parentUri the site URI of the parent project
+     * @param childUri the site URI of the child project
+     * @return {@code true} if both URIs describe the same site
+     */
+    static boolean isScmUrl(String url) {
+        return url != null && url.startsWith("scm:");
+    }
+
+    static boolean isSameRepositoryPath(URI parentUri, URI childUri) {
+        if (!Objects.equals(parentUri.getHost(), childUri.getHost())) {
+            return false;
+        }
+
+        String parentPath = stripTrailingSlash(parentUri.getPath());
+        String childPath = stripTrailingSlash(childUri.getPath());
+        if (parentPath == null || childPath == null) {
+            // an opaque URI neither the SCM unwrapping nor URI parsing could resolve; treat the sites as separate
+            return false;
+        }
+
+        // compare whole segments, so that /foo does not contain /foobar
+        return childPath.equals(parentPath) || childPath.startsWith(parentPath + "/");
+    }
+
+    private static String stripTrailingSlash(String path) {
+        if (path != null && path.endsWith("/")) {
+            return path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
+    /**
      * Extract the distributionManagement site of the top level parent of the given MavenProject.
      * This climbs up the project hierarchy and returns the site of the last project
      * for which {@link #getSite(org.apache.maven.project.MavenProject)} returns a site that resides in the
@@ -550,10 +653,20 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
             }
 
             // MSITE-600
-            URIPathDescriptor siteURI = new URIPathDescriptor(URIEncoder.encodeURI(site.getUrl()), "");
-            URIPathDescriptor oldSiteURI = new URIPathDescriptor(URIEncoder.encodeURI(oldSite.getUrl()), "");
+            // MSITE-1033: For SCM URLs, extract the provider-specific part for comparison
+            String siteUrlToCompare = extractComparableUrl(site.getUrl());
+            String oldSiteUrlToCompare = extractComparableUrl(oldSite.getUrl());
 
-            if (!siteURI.sameSite(oldSiteURI.getBaseURI())) {
+            URIPathDescriptor siteURI = new URIPathDescriptor(URIEncoder.encodeURI(siteUrlToCompare), "");
+            URIPathDescriptor oldSiteURI = new URIPathDescriptor(URIEncoder.encodeURI(oldSiteUrlToCompare), "");
+
+            // an SCM URL names a repository, so the path decides; a deployment URL keeps the older, looser
+            // rule, under which a child may sit anywhere on the same server and still be one site
+            boolean sameSite = isScmUrl(site.getUrl()) || isScmUrl(oldSite.getUrl())
+                    ? isSameRepositoryPath(siteURI.getBaseURI(), oldSiteURI.getBaseURI())
+                    : siteURI.sameSite(oldSiteURI.getBaseURI());
+
+            if (!sameSite) {
                 return oldProject;
             }
         }

--- a/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojo.java
@@ -535,48 +535,61 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
      */
     static String extractComparableUrl(String url) {
         if (url != null && url.startsWith("scm:")) {
-            // Extract the SCM provider (e.g., "git", "svn")
-            String provider = ScmUrlUtils.getProvider(url);
+            try {
+                // Extract the SCM provider (e.g., "git", "svn")
+                String provider = ScmUrlUtils.getProvider(url);
 
-            // Extract the provider-specific part of the SCM URL
-            // For example: "scm:git:https://github.com/user/repo.git" -> "https://github.com/user/repo.git"
-            String providerSpecificPart = ScmUrlUtils.getProviderSpecificPart(url);
-            if (providerSpecificPart != null && !providerSpecificPart.isEmpty()) {
-                // Handle SCP-like Git syntax (e.g., git@github.com:user/repo.git or user@host:path)
-                // Convert it to a more standard format for comparison
-                // Note: This is a heuristic check - we look for the pattern of user@host:path
-                // where the colon comes after the @ symbol and is followed by a path
-                if (providerSpecificPart.contains("@")
-                        && !providerSpecificPart.startsWith("http://")
-                        && !providerSpecificPart.startsWith("https://")
-                        && !providerSpecificPart.startsWith("ssh://")) {
-                    // Find the @ symbol and look for the first : after it that's not part of a URL scheme
-                    int atIndex = providerSpecificPart.lastIndexOf('@');
-                    int colonIndex = providerSpecificPart.indexOf(':', atIndex);
+                // Extract the provider-specific part of the SCM URL
+                // For example: "scm:git:https://github.com/user/repo.git" -> "https://github.com/user/repo.git"
+                String providerSpecificPart = ScmUrlUtils.getProviderSpecificPart(url);
+                if (providerSpecificPart != null && !providerSpecificPart.isEmpty()) {
+                    // Handle SCP-like Git syntax (e.g., git@github.com:user/repo.git or user@host:path)
+                    // Convert it to a more standard format for comparison
+                    // Note: This is a heuristic check - we look for the pattern of user@host:path
+                    // where the colon comes after the @ symbol and is followed by a path
+                    if (providerSpecificPart.contains("@")
+                            && !providerSpecificPart.startsWith("http://")
+                            && !providerSpecificPart.startsWith("https://")
+                            && !providerSpecificPart.startsWith("ssh://")) {
+                        // Find the @ symbol and look for the first : after it that's not part of a URL scheme
+                        int atIndex = providerSpecificPart.lastIndexOf('@');
+                        int colonIndex;
+                        if (atIndex >= 0
+                                && atIndex + 1 < providerSpecificPart.length()
+                                && providerSpecificPart.charAt(atIndex + 1) == '[') {
+                            int closingBracket = providerSpecificPart.indexOf(']', atIndex + 1);
+                            colonIndex = (closingBracket > 0) ? providerSpecificPart.indexOf(':', closingBracket) : -1;
+                        } else {
+                            colonIndex = (atIndex >= 0) ? providerSpecificPart.indexOf(':', atIndex) : -1;
+                        }
 
-                    // Verify this looks like SCP syntax: user@host:path
-                    // The colon should come after @ and before the end
-                    if (atIndex >= 0 && colonIndex > atIndex + 1 && colonIndex < providerSpecificPart.length() - 1) {
-                        String host = providerSpecificPart.substring(atIndex + 1, colonIndex);
-                        String path = providerSpecificPart.substring(colonIndex + 1);
-                        // Convert to a pseudo-URL format for comparison
-                        // Note: IPv6 addresses in brackets are handled by this approach
-                        // as the brackets will be preserved in the host part
-                        return "ssh://" + host + "/" + path;
+                        // Verify this looks like SCP syntax: user@host:path
+                        // The colon should come after @ and before the end
+                        if (atIndex >= 0
+                                && colonIndex > atIndex + 1
+                                && colonIndex < providerSpecificPart.length() - 1) {
+                            String host = providerSpecificPart.substring(atIndex + 1, colonIndex);
+                            String path = providerSpecificPart.substring(colonIndex + 1);
+                            // Convert to a pseudo-URL format for comparison
+                            return "ssh://" + host + "/" + path;
+                        }
                     }
-                }
 
-                // For hierarchical VCS systems like SVN, normalize the scheme to allow
-                // comparison of URLs that differ only in http vs https
-                // SVN repositories can be accessed via both protocols and should be considered the same
-                if ("svn".equalsIgnoreCase(provider) && providerSpecificPart.startsWith("https://")) {
-                    // Normalize https to http for SVN URLs to enable proper comparison
-                    return "http" + providerSpecificPart.substring(5);
-                }
+                    // For hierarchical VCS systems like SVN, normalize the scheme to allow
+                    // comparison of URLs that differ only in http vs https
+                    // SVN repositories can be accessed via both protocols and should be considered the same
+                    if ("svn".equalsIgnoreCase(provider) && providerSpecificPart.startsWith("https://")) {
+                        // Normalize https to http for SVN URLs to enable proper comparison
+                        return "http" + providerSpecificPart.substring(5);
+                    }
 
-                // Return the provider-specific part as-is for standard URLs or
-                // if SCP syntax conversion is not applicable
-                return providerSpecificPart;
+                    // Return the provider-specific part as-is for standard URLs or
+                    // if SCP syntax conversion is not applicable
+                    return providerSpecificPart;
+                }
+            } catch (IllegalArgumentException e) {
+                // Malformed SCM URL; fall back to original URL
+                return url;
             }
         }
         return url;
@@ -584,7 +597,7 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
 
     /**
      * Returns whether a child repository lies within a parent repository, which is what makes them one site
-     * to deploy. The host must match and the child path must be the parent path or below it.
+     * to deploy. The host and port must match and the child path must be the parent path or below it.
      * <p>
      * Host, scheme and port alone do not tell them apart: two repositories on the same forge, such as
      * {@code github.com/org/parent.git} and {@code github.com/org/child.git}, share all three and are still
@@ -600,7 +613,7 @@ public abstract class AbstractDeployMojo extends AbstractSiteMojo {
     }
 
     static boolean isSameRepositoryPath(URI parentUri, URI childUri) {
-        if (!Objects.equals(parentUri.getHost(), childUri.getHost())) {
+        if (!Objects.equals(parentUri.getHost(), childUri.getHost()) || parentUri.getPort() != childUri.getPort()) {
             return false;
         }
 

--- a/src/test/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojoTest.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.site.deploy;
+
+import org.apache.maven.model.DistributionManagement;
+import org.apache.maven.model.Site;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for AbstractDeployMojo.
+ */
+public class AbstractDeployMojoTest {
+
+    /**
+     * Test that getTopLevelProject correctly handles SCM URLs with different repositories.
+     * This is the test case for MSITE-1033.
+     */
+    @Test
+    public void testGetTopLevelProjectWithDifferentScmUrls() throws Exception {
+        // Create a mock deploy mojo
+        TestDeployMojo mojo = new TestDeployMojo();
+
+        // Create child project with SCM URL
+        MavenProject childProject =
+                createProjectWithSite("child", "scm:git:git@github.com:codehaus-plexus/plexus-sec-dispatcher.git/");
+
+        // Create parent project with different SCM URL
+        MavenProject parentProject =
+                createProjectWithSite("parent", "scm:git:https://github.com/codehaus-plexus/plexus-pom.git/");
+
+        // Set up the parent-child relationship
+        childProject.setParent(parentProject);
+
+        // Call getTopLevelProject - it should return childProject, not parentProject
+        // because the SCM URLs point to different repositories
+        MavenProject topProject = mojo.getTopLevelProject(childProject);
+
+        // The top project should be the child project itself since the parent has a different site
+        assertEquals(childProject, topProject, "Top project should be child project due to different SCM URLs");
+    }
+
+    /**
+     * Test that getTopLevelProject correctly handles SCM URLs with the same repository.
+     */
+    @Test
+    public void testGetTopLevelProjectWithSameScmUrls() throws Exception {
+        // Create a mock deploy mojo
+        TestDeployMojo mojo = new TestDeployMojo();
+
+        // Create child project with SCM URL
+        MavenProject childProject =
+                createProjectWithSite("child", "scm:git:https://github.com/codehaus-plexus/plexus-pom.git/child");
+
+        // Create parent project with same base SCM URL
+        MavenProject parentProject =
+                createProjectWithSite("parent", "scm:git:https://github.com/codehaus-plexus/plexus-pom.git/");
+
+        // Set up the parent-child relationship
+        childProject.setParent(parentProject);
+
+        // Call getTopLevelProject - it should return parentProject
+        // because the SCM URLs point to the same repository
+        MavenProject topProject = mojo.getTopLevelProject(childProject);
+
+        // The top project should be the parent project since they share the same site
+        assertEquals(parentProject, topProject, "Top project should be parent project due to same SCM base URL");
+    }
+
+    /**
+     * Test that getTopLevelProject correctly handles non-SCM URLs.
+     */
+    @Test
+    public void testGetTopLevelProjectWithNonScmUrls() throws Exception {
+        // Create a mock deploy mojo
+        TestDeployMojo mojo = new TestDeployMojo();
+
+        // Create child project with regular URL
+        MavenProject childProject = createProjectWithSite("child", "https://example.com/site/child");
+
+        // Create parent project with same base URL
+        MavenProject parentProject = createProjectWithSite("parent", "https://example.com/site/");
+
+        // Set up the parent-child relationship
+        childProject.setParent(parentProject);
+
+        // Call getTopLevelProject - it should return parentProject
+        MavenProject topProject = mojo.getTopLevelProject(childProject);
+
+        // The top project should be the parent project since they share the same site
+        assertEquals(parentProject, topProject, "Top project should be parent project for regular URLs");
+    }
+
+    /**
+     * Test that getTopLevelProject correctly handles SCM URLs with standard https format.
+     */
+    @Test
+    public void testGetTopLevelProjectWithHttpsScmUrls() throws Exception {
+        // Create a mock deploy mojo
+        TestDeployMojo mojo = new TestDeployMojo();
+
+        // Create child project with https SCM URL
+        MavenProject childProject = createProjectWithSite("child", "scm:git:https://github.com/user/repo1.git/");
+
+        // Create parent project with different https SCM URL (different domain)
+        MavenProject parentProject = createProjectWithSite("parent", "scm:git:https://gitlab.com/user/repo2.git/");
+
+        // Set up the parent-child relationship
+        childProject.setParent(parentProject);
+
+        // Call getTopLevelProject - it should return childProject
+        // because the SCM URLs point to different repositories
+        MavenProject topProject = mojo.getTopLevelProject(childProject);
+
+        // The top project should be the child project itself since the parent has a different site
+        assertEquals(childProject, topProject, "Top project should be child project due to different https SCM URLs");
+    }
+
+    /**
+     * The reported case: sibling repositories on the same host. plexus-xml inherits from plexus-pom,
+     * they share github.com, and their sites are unrelated.
+     */
+    @Test
+    public void testGetTopLevelProjectWithSiblingRepositoriesOnSameHost() throws Exception {
+        TestDeployMojo mojo = new TestDeployMojo();
+
+        MavenProject childProject =
+                createProjectWithSite("child", "scm:git:https://github.com/codehaus-plexus/plexus-xml.git");
+        MavenProject parentProject =
+                createProjectWithSite("parent", "scm:git:https://github.com/codehaus-plexus/plexus-pom.git");
+
+        childProject.setParent(parentProject);
+
+        MavenProject topProject = mojo.getTopLevelProject(childProject);
+
+        assertEquals(childProject, topProject, "Sibling repositories do not share a site");
+    }
+
+    /**
+     * Test that extractComparableUrl properly handles SVN URLs with different schemes but same host.
+     * For SVN (hierarchical VCS), URLs with different schemes (http vs https) should be normalized
+     * to the same scheme to allow URIPathDescriptor.sameSite() to recognize them as the same site.
+     * Note: The paths may differ (one being a subpath of another), but as long as scheme, host, and port
+     * are the same, URIPathDescriptor.sameSite() will correctly identify them as the same site.
+     */
+    @Test
+    public void testExtractComparableUrlForSvnUrls() throws Exception {
+        // Extract and normalize both URLs
+        String url1 = AbstractDeployMojo.extractComparableUrl("scm:svn:http://svn.apache.org/repos/asf/maven/website");
+        String url2 = AbstractDeployMojo.extractComparableUrl(
+                "scm:svn:https://svn.apache.org/repos/asf/maven/website/components");
+
+        // Both should be normalized to http scheme
+        assertEquals("http://svn.apache.org/repos/asf/maven/website", url1);
+        assertEquals("http://svn.apache.org/repos/asf/maven/website/components", url2);
+
+        // Now verify they would be considered the same site by creating projects with these URLs
+        TestDeployMojo mojo = new TestDeployMojo();
+        MavenProject childProject =
+                createProjectWithSite("child", "scm:svn:https://svn.apache.org/repos/asf/maven/website/components");
+        MavenProject parentProject =
+                createProjectWithSite("parent", "scm:svn:http://svn.apache.org/repos/asf/maven/website");
+        childProject.setParent(parentProject);
+
+        // The parent should be returned as the top project since they share the same SVN site
+        MavenProject topProject = mojo.getTopLevelProject(childProject);
+        assertEquals(
+                parentProject,
+                topProject,
+                "Top project should be parent due to normalized SVN URLs pointing to same site");
+    }
+
+    private MavenProject createProjectWithSite(String artifactId, String siteUrl) {
+        MavenProject project = new MavenProject();
+        project.setGroupId("org.apache.maven.test");
+        project.setArtifactId(artifactId);
+        project.setVersion("1.0");
+        project.setName(artifactId);
+
+        DistributionManagement distributionManagement = new DistributionManagement();
+        Site site = new Site();
+        site.setId("test-site");
+        site.setUrl(siteUrl);
+        distributionManagement.setSite(site);
+        project.setDistributionManagement(distributionManagement);
+
+        return project;
+    }
+
+    /**
+     * Test implementation of AbstractDeployMojo for testing.
+     */
+    private static class TestDeployMojo extends AbstractDeployMojo {
+        @Override
+        protected boolean isDeploy() {
+            return true;
+        }
+
+        @Override
+        protected String determineTopDistributionManagementSiteUrl() throws MojoExecutionException {
+            return "test";
+        }
+
+        @Override
+        protected Site determineDeploySite() throws MojoExecutionException {
+            Site site = new Site();
+            site.setId("test");
+            site.setUrl("test");
+            return site;
+        }
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/site/deploy/AbstractDeployMojoTest.java
@@ -158,9 +158,7 @@ public class AbstractDeployMojoTest {
     /**
      * Test that extractComparableUrl properly handles SVN URLs with different schemes but same host.
      * For SVN (hierarchical VCS), URLs with different schemes (http vs https) should be normalized
-     * to the same scheme to allow URIPathDescriptor.sameSite() to recognize them as the same site.
-     * Note: The paths may differ (one being a subpath of another), but as long as scheme, host, and port
-     * are the same, URIPathDescriptor.sameSite() will correctly identify them as the same site.
+     * to the same scheme to allow site inheritance to recognize them as the same site.
      */
     @Test
     public void testExtractComparableUrlForSvnUrls() throws Exception {
@@ -187,6 +185,31 @@ public class AbstractDeployMojoTest {
                 parentProject,
                 topProject,
                 "Top project should be parent due to normalized SVN URLs pointing to same site");
+    }
+
+    @Test
+    public void testExtractComparableUrlWithBracketedIpv6() {
+        String url = AbstractDeployMojo.extractComparableUrl("scm:git:git@[2001:db8::1]:user/repo.git");
+        assertEquals("ssh://[2001:db8::1]/user/repo.git", url);
+    }
+
+    @Test
+    public void testExtractComparableUrlWithMalformedScmUrl() {
+        String malformedUrl = "scm:invalid";
+        String result = AbstractDeployMojo.extractComparableUrl(malformedUrl);
+        assertEquals(malformedUrl, result);
+    }
+
+    @Test
+    public void testGetTopLevelProjectWithDifferentPorts() throws Exception {
+        TestDeployMojo mojo = new TestDeployMojo();
+        MavenProject childProject =
+                createProjectWithSite("child", "scm:git:https://example.com:8443/org/repo.git/child");
+        MavenProject parentProject = createProjectWithSite("parent", "scm:git:https://example.com:9443/org/repo.git/");
+        childProject.setParent(parentProject);
+
+        MavenProject topProject = mojo.getTopLevelProject(childProject);
+        assertEquals(childProject, topProject, "Projects with different ports should not share a site");
     }
 
     private MavenProject createProjectWithSite(String artifactId, String siteUrl) {


### PR DESCRIPTION
Fixes #1159. Same approach as #227, rebased onto current master, which #227 no longer merges cleanly against — credit to @kwin for the diagnosis and for the unwrap-then-compare shape.

`getTopLevelProject` compares `distributionManagement.site.url` through `URIPathDescriptor.sameSite()`, which needs a hierarchical URI. An SCM URL such as `scm:git:https://github.com/org/repo.git` is opaque, so scheme, host and port parse as `scm`, `null` and `-1`: every SCM URL matches every other, and a project inherits a top-level project it shares nothing with.

Two parts, and the second is easy to miss:

1. Unwrap the provider-specific part through `ScmUrlUtils`, converting SCP-like `git@host:path` to `ssh://host/path` and normalising svn `https` to `http`, so the two access schemes of one repository still match.
2. Compare host **and** path. Unwrapping alone leaves two repositories on one forge sharing scheme, host and port, so `sameSite()` still calls them one site. For an SCM URL the path names the repository, so the child path must lie under the parent path, whole segments only, so `/foo` does not contain `/foobar`.

**Deployment URLs keep `sameSite()` unchanged.** Applying the path rule to every URL breaks the `site-inheritance` IT, which covers a child sitting at an unrelated path on the same server and still being staged as part of its parent site. That looks deliberate, and this change leaves it alone rather than deciding it.

Six unit tests, including the sibling-repository case that fails with unwrapping alone. All 62 integration tests pass.

Verified: with 3.22.1-SNAPSHOT, plexus-xml — a single-module project whose site URL is an SCM URL — stages into `target/staging` with 216 files, where 3.22.0 staged into `target/staging/../plexus-xml.git` with none. That is the downstream report in codehaus-plexus/plexus-pom#333.

*This change was created with AI assistance.*