### PR TITLE
Document the Doxia 2 migration and upgrade the ITs to Fluido Skin 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@ under the License.
     <jxrPluginVersion>3.5.0</jxrPluginVersion>
     <taglistPluginVersion>3.2.1</taglistPluginVersion>
     <mavenReportingImplVersion>4.0.0</mavenReportingImplVersion>
-    <fluidoSkinVersion>2.0.0-M11</fluidoSkinVersion>
+    <fluidoSkinVersion>2.1.0</fluidoSkinVersion>
     <project.build.outputTimestamp>2026-05-20T15:10:39Z</project.build.outputTimestamp>
   </properties>
 
@@ -506,7 +506,6 @@ under the License.
               <settingsFile>src/it/mrm/settings.xml</settingsFile>
               <filterProperties>
                 <mrm.repository.url>${mrm.repository.url}</mrm.repository.url>
-                <fluidoSkinVersion>${testingFluidoSkinVersion}</fluidoSkinVersion>
               </filterProperties>
               <goals>
                 <goal>clean</goal>

--- a/src/it/projects/MSITE-159/verify.bsh
+++ b/src/it/projects/MSITE-159/verify.bsh
@@ -41,9 +41,9 @@ try
     }
 
     String content = FileUtils.fileRead( index, "UTF-8" );
-    int index1 = content.indexOf( "<a href=\"http://webhost.company.com/index.html\" class=\"externalLink\">Breadcrumb</a>" );
-    int index2 = content.indexOf( "<a href=\"http://webhost.company.com/\" class=\"externalLink\">Link</a>" );
-    int index3 = content.indexOf( "<a href=\"http://webhost.company.com/\" class=\"externalLink\">Menu</a>" );
+    int index1 = content.indexOf( "<a href=\"http://webhost.company.com/index.html\">Breadcrumb</a>" );
+    int index2 = content.indexOf( "<a href=\"http://webhost.company.com/\">Link</a>" );
+    int index3 = content.indexOf( "<a href=\"http://webhost.company.com/\">Menu</a>" );
     if ( index1 < 0 || index2 < 0 || index3 < 0 )
     {
         System.err.println( "index.html has incorrect links!" );

--- a/src/site/markdown/examples/creatingskins.md
+++ b/src/site/markdown/examples/creatingskins.md
@@ -55,7 +55,7 @@ Once the JAR is built and deployed, it can be used by projects.
 
 <!-- @todo More information is needed here on constructing the CSS-->
 
-If you are interested in constructing your own CSS, it is recommended that you copy the file [`maven-theme.css`](https://github.com/apache/maven-default-skin/tree/master/src/main/resources/css/maven-theme.css) from Maven Default Skin and modify it to suit your needs.
+If you are interested in constructing your own CSS, it is recommended that you copy the file [`maven-theme.css`](https://github.com/apache/maven-fluido-skin/tree/master/src/main/resources/css/maven-theme.css) from Maven Fluido Skin and modify it to suit your needs.
 
 ## Customizing the HTML Output with a Velocity Template
 

--- a/src/site/markdown/examples/sitedescriptor.md
+++ b/src/site/markdown/examples/sitedescriptor.md
@@ -279,7 +279,7 @@ Skins can be created to customize the look and feel of a site in a consistent wa
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.8</version>
+    <version>2.1.0</version>
   </skin>
   ...
 </site>
@@ -289,7 +289,7 @@ Skins can be created to customize the look and feel of a site in a consistent wa
 
 This skin will copy the necessary resources including CSS and if necessary use the included alternate Velocity template to render the site.
 
-If you don&apos;t specify a skin, the Site Plugin will use [Maven Default Skin](/skins/maven-default-skin/).
+Since version 3\.20\.0 a skin is mandatory: the site descriptor no longer carries a built-in default skin, and the build fails with `No skin is declared in the site descriptor` when none is found. The skin is normally inherited from the parent&apos;s site descriptor, so most projects never declare one themselves; projects inheriting from [Apache Parent POM](https://maven.apache.org/pom/asf/) get [Maven Fluido Skin](/skins/maven-fluido-skin/) that way. If you see that failure, check that the parent site descriptor is resolvable before adding a `<skin>` of your own.
 
 ## Custom Properties
 

--- a/src/site/markdown/migrate.md
+++ b/src/site/markdown/migrate.md
@@ -29,6 +29,17 @@ under the License.
 
 The Site Plugin has had a couple of upgrades that requires the user to make adjustments to their environment, documents or configuration. Below is a list of key changes and what updates you as a user need to be aware of: you can have a look at [history](./history.html) for precise details of internal components updates.
 
+## From 3\.12\.x to 3\.20\.0
+
+Version 3\.20\.0 moves the plugin onto the [Doxia 2\.0\.0 stack](/doxia/) and Maven Reporting API 4\.0\.0. It is the Doxia 2 line for Maven 3\.x, and the gap after 3\.12\.x is deliberate: 4\.0\.0 is reserved for Maven 4.
+
+- Reports are loaded through Maven Reporting API 4\.0\.0, so report plugins built against Maven Reporting API 3\.x no longer run. Upgrade every report plugin along with the Site Plugin.
+- A skin is mandatory. The site descriptor no longer carries a built-in default skin, and the build fails with `No skin is declared in the site descriptor` when none is found. Projects inheriting from the [Apache Parent POM](/pom/asf/) pick up [Maven Fluido Skin](/skins/maven-fluido-skin/) through the inherited site descriptor, so if that failure appears, first check that the parent site descriptor is resolvable.
+- The site descriptor has a second model version, with `site` as its root element and the `http://maven.apache.org/SITE/2.0.0` namespace, described in the [site descriptor reference](/doxia/doxia-sitetools/doxia-site-model/site.html). Descriptors written against the v1 model are still read and converted on the fly; [convert them](/doxia/doxia-sitetools/doxia-site-model/convert-to-sitedescriptor-2.x.html) when convenient.
+- The default locale is the root locale, written `default` in the `locales` parameter. When you render several locales, list `default` among them, otherwise nothing is generated at the root of the output directory.
+- Documents are rendered as XHTML5, and section titles start at `h1` where they previously started at `h2`. Skins and stylesheets that select on heading level need to be adjusted.
+- Site descriptors cached in your local repository by earlier runs can be 0-byte markers that shadow the remote ones. Delete them once: `find ~/.m2/repository -name \*site\*.xml -size 0 -delete`
+
 ## From 3\.4 to 3\.5\.1
 
 - Since [Velocity](http://velocity.apache.org) has been upgraded from version 1\.5 to version 1\.7, which changes escaping rules, you may need to update escape sequences in your `.vm` documents and/or skins. If you can&apos;t update content and/or skin immediately, you can manually downgrade Velocity version by configuring a dependency to Maven Site Plugin:


### PR DESCRIPTION
Closes the documentation half of the Doxia 2 adoption for this plugin, and moves the ITs onto the current skin.

- `migrate.md` had no entry newer than "From 3.4 to 3.5.1", so the 3.12.x → 3.20.0 notes (mandatory skin, root locale spelled `default`, site descriptor v2, XHTML5 heading levels, stale 0-byte descriptors in the local repository) lived only on the wiki.
- `examples/sitedescriptor.md` still promised that an absent skin falls back to Maven Default Skin. Since 3.20.0 that is a `MojoFailureException`; the page now says so and points at inheritance, which is where nearly every project gets its skin. The example pinned Fluido Skin 1.8.
- `examples/creatingskins.md` sourced `maven-theme.css` from the archived `apache/maven-default-skin`; the same file lives in Fluido Skin.
- The ITs pinned Fluido Skin 2.0.0-M11, and `filterProperties` still referenced `testingFluidoSkinVersion`, which no longer exists — MSITE-1009 renamed it back in 2024.

The skin bump makes MSITE-159 fail, because Fluido Skin 2.1.0 deliberately drops the `externalLink` class (MSKINS-262). The assertion now matches the anchor without it; the links themselves are unchanged.

Verified: `mvn -Prun-its verify` on this branch → Passed: 62, Failed: 0, Errors: 0.

*This change was created with AI assistance.*
