### PR TITLE
Point the document renderers at getOutputPath()

### DIFF
--- a/src/main/java/org/apache/maven/plugins/site/render/CategorySummaryDocumentRenderer.java
+++ b/src/main/java/org/apache/maven/plugins/site/render/CategorySummaryDocumentRenderer.java
@@ -179,9 +179,18 @@ public class CategorySummaryDocumentRenderer implements SitePluginReportDocument
         siteRenderer.mergeDocumentIntoSite(writer, sink, siteRenderingContext);
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
     @Override
+    @Deprecated
     public String getOutputName() {
-        return docRenderingContext.getOutputName();
+        return getOutputPath();
+    }
+
+    @Override
+    public String getOutputPath() {
+        return docRenderingContext.getOutputPath();
     }
 
     @Override

--- a/src/main/java/org/apache/maven/plugins/site/render/ReportDocumentRenderer.java
+++ b/src/main/java/org/apache/maven/plugins/site/render/ReportDocumentRenderer.java
@@ -248,14 +248,18 @@ public class ReportDocumentRenderer implements DocumentRenderer {
         }
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
     @Override
+    @Deprecated
     public String getOutputName() {
-        return docRenderingContext.getOutputName();
+        return getOutputPath();
     }
 
     @Override
     public String getOutputPath() {
-        return getOutputName();
+        return docRenderingContext.getOutputPath();
     }
 
     @Override

--- a/src/main/java/org/apache/maven/plugins/site/render/SitemapDocumentRenderer.java
+++ b/src/main/java/org/apache/maven/plugins/site/render/SitemapDocumentRenderer.java
@@ -163,14 +163,18 @@ public class SitemapDocumentRenderer implements SitePluginReportDocumentRenderer
         return href.startsWith("/") ? "." + href : href;
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
     @Override
+    @Deprecated
     public String getOutputName() {
-        return docRenderingContext.getOutputName();
+        return getOutputPath();
     }
 
     @Override
     public String getOutputPath() {
-        return getOutputName();
+        return docRenderingContext.getOutputPath();
     }
 
     @Override


### PR DESCRIPTION
`DocumentRenderer#getOutputPath()` was added in Doxia Sitetools 2.0.0 and `getOutputName()` deprecated in its favour. The adoption here was cosmetic: `ReportDocumentRenderer` and `SitemapDocumentRenderer` implemented `getOutputPath()` as `return getOutputName();`, which is exactly what the interface default does, and `CategorySummaryDocumentRenderer` implemented only the deprecated method. Every path still ended in `getOutputName()`.

All three now hold the value in `getOutputPath()`, reading `DocumentRenderingContext#getOutputPath()` rather than the equally deprecated `#getOutputName()`, with `getOutputName()` left as a deprecated delegate because the interface still declares it abstract. No behaviour change: the strings are the same.

The counterpart in Doxia Sitetools is apache/maven-doxia-sitetools#690.

Verified: `mvn verify` → BUILD SUCCESS.

*This change was created with AI assistance.*
