### PR TITLE
Implement getOutputPath() in the report fixtures

### DIFF
--- a/src/it/projects/MSITE-627/src/main/java/org/apache/maven/plugins/it/MyReport.java
+++ b/src/it/projects/MSITE-627/src/main/java/org/apache/maven/plugins/it/MyReport.java
@@ -38,7 +38,16 @@ public class MyReport
     extends AbstractMavenReport
 {
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Deprecated
     public String getOutputName()
+    {
+        return getOutputPath();
+    }
+
+    public String getOutputPath()
     {
         return "MSITE-627";
     }

--- a/src/it/projects/MSITE-842/project/src/main/java/org/apache/maven/plugins/it/MyReport.java
+++ b/src/it/projects/MSITE-842/project/src/main/java/org/apache/maven/plugins/it/MyReport.java
@@ -37,7 +37,16 @@ public class MyReport
     extends AbstractMavenReport
 {
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Deprecated
     public String getOutputName()
+    {
+        return getOutputPath();
+    }
+
+    public String getOutputPath()
     {
         return "MSITE-842";
     }


### PR DESCRIPTION
The report fixtures under `src/it` still implement only the deprecated `getOutputName()`. They are what a plugin author copies when writing a report, so they should show the pattern the [report plugin guide](https://maven.apache.org/guides/plugin/guide-java-report-plugin-development.html) asks for: `getOutputPath()` carries the value, `getOutputName()` stays as a deprecated delegate because Maven Reporting API 4.0.0 still declares it abstract.

The two `MyReport` fixtures, in the MSITE-627 and MSITE-842 IT projects.

No behaviour change — the paths are the same strings. Formatting follows each file's existing brace style rather than the modern one, so the diff stays additive.

Verified: `mvn -Prun-its verify -Dinvoker.test=MSITE-627,MSITE-842` → Passed: 2, Failed: 0.

*This change was created with AI assistance.*
