### PR TITLE
Simplify _extends in release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-_extends: maven-gh-actions-shared:/.github/release-drafter.yml
+_extends: maven-gh-actions-shared
 tag-template: maven-site-plugin-$RESOLVED_VERSION


### PR DESCRIPTION
Release-drafter resolves `maven-gh-actions-shared` to `.github/release-drafter.yml`
by default; the explicit path is redundant. Same form as the other Maven repos.